### PR TITLE
Validate duration strings using survey's validation API

### DIFF
--- a/cmd/kion/setup/setup.go
+++ b/cmd/kion/setup/setup.go
@@ -122,6 +122,14 @@ func run(userConfigPath string) error {
 		&survey.Input{Message: "Duration of temporary credentials:", Default: "60m"},
 		&sessionDuration,
 		survey.WithValidator(survey.Required),
+		survey.WithValidator(func(t interface{}) error {
+			tStr, isStr := t.(string)
+			if !isStr {
+				return fmt.Errorf("%s is not a string", t)
+			}
+			_, err = time.ParseDuration(tStr)
+			return err
+		}),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
That way if it is invalid it is handled using survey's retry logic instead of exiting the program.

Unfortunately survey doesn't document how they parse durations (they just say they will "cast" the string into its target type) but it seems unlikely that they will switch to a different method.

Testing: put some invalid durations and then a valid one.

## PR Checklist
* [ ] **New automated tests have been written to the extent possible.**
* [x] **The code has been checked for structural/syntactic validity.**
	- AMI/application: a build was performed
	- terraform changes: "terraform plan" checked on every affected environment
* [ ] **(If applicable) the code has been manually tested on our infrastructure.**
	- AMI/application: deployed an a test or dev environment
	- terraform changes: applied to test or dev environment
	- script: run against test or dev environment
* [x] **Likely failure points and new functionality have been identified and tested manually.**
	Examples:
	- Application manually run in a way that triggers any new branches
	- AMI logged into and changes verified from login shell
* [x] **Pull request description includes a description of all the manual steps performed to accomplish the above.**

To provide feedback on this template, visit https://docs.google.com/document/d/1YfTv7Amyop5G_8w1c2GJ_Mu-70L0KkZHhm9f9umDi3U/edit
