### PR TITLE
Automatically rotate App API Keys

### DIFF
--- a/cmd/kion/key/key.go
+++ b/cmd/kion/key/key.go
@@ -85,8 +85,13 @@ func runCreate(cfg *config.Config, keyCfg *config.KeyConfig) error {
 	if err != nil {
 		return err
 	}
+	keyMetadata, err := kion.GetAppAPIKeyMetadata(key.ID)
+	if err != nil {
+		return err
+	}
 
 	keyCfg.Key = key.Key
+	keyCfg.Created = keyMetadata.Created
 	return keyCfg.Save()
 }
 
@@ -103,7 +108,13 @@ func runRotate(cfg *config.Config, keyCfg *config.KeyConfig) error {
 	} else if err != nil {
 		return err
 	}
+	kion = client.NewWithAppAPIKey(host, key.Key)
+	keyMetadata, err := kion.GetAppAPIKeyMetadata(key.ID)
+	if err != nil {
+		return err
+	}
 
 	keyCfg.Key = key.Key
+	keyCfg.Created = keyMetadata.Created
 	return keyCfg.Save()
 }

--- a/cmd/kion/util/util.go
+++ b/cmd/kion/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/corbaltcode/kion/cmd/kion/config"
 	"github.com/corbaltcode/kion/internal/client"
@@ -17,6 +18,34 @@ func NewClient(cfg *config.Config, keyCfg *config.KeyConfig) (*client.Client, er
 	}
 
 	if keyCfg.Key != "" {
+		if cfg.Bool("rotate-app-api-keys") {
+			duration, err := cfg.DurationErr("app-api-key-duration")
+			if err != nil {
+				return nil, err
+			}
+
+			// rotate if expiring within three days
+			if keyCfg.Created.Add(duration).Before(time.Now().Add(time.Hour * 72)) {
+				kion := client.NewWithAppAPIKey(host, keyCfg.Key)
+				key, err := kion.RotateAppAPIKey(keyCfg.Key)
+				if err != nil {
+					return nil, err
+				}
+				kion = client.NewWithAppAPIKey(host, key.Key)
+				keyMetadata, err := kion.GetAppAPIKeyMetadata(key.ID)
+				if err != nil {
+					return nil, err
+				}
+
+				keyCfg.Key = key.Key
+				keyCfg.Created = keyMetadata.Created
+				err = keyCfg.Save()
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+
 		return client.NewWithAppAPIKey(host, keyCfg.Key), nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/relvacode/iso8601 v1.3.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/term v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/relvacode/iso8601 v1.3.0 h1:HguUjsGpIMh/zsTczGN3DVJFxTU/GX+MMmzcKoMO7ko=
+github.com/relvacode/iso8601 v1.3.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH2h3sZCn0I=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
 github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=


### PR DESCRIPTION
## PR Description
Adds automatic key rotation. When a command requiring authentication is run, an App API Key is being used, and the key expires within three days, it is automatically rotated. This should prevent folks from forgetting to rotate their keys and having to run `key create --force`.

Tested:
- Manual testing of various commands