### PR TITLE
Flag for logging out of AWS console

### DIFF
--- a/cmd/kion/console/console.go
+++ b/cmd/kion/console/console.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/corbaltcode/kion/cmd/kion/config"
 	"github.com/corbaltcode/kion/cmd/kion/util"
@@ -26,6 +27,7 @@ func New(cfg *config.Config, keyCfg *config.KeyConfig) *cobra.Command {
 	cmd.Flags().StringP("account-id", "", "", "AWS account ID")
 	cmd.Flags().StringP("cloud-access-role", "", "", "cloud access role")
 	cmd.Flags().BoolP("print", "p", false, "print URL instead of opening a browser")
+	cmd.Flags().BoolP("logout", "", false, "log out of existing AWS console session")
 	cmd.Flags().StringP("region", "", "", "AWS region")
 	cmd.Flags().StringP("session-duration", "", "1h", "duration of temporary credentials")
 
@@ -74,6 +76,12 @@ func run(cfg *config.Config, keyCfg *config.KeyConfig) error {
 
 	if cfg.Bool("print") {
 		fmt.Println(signinUrl)
+	} else if cfg.Bool("logout") {
+		html := fmt.Sprintf(logoutHtmlTemplate, signinUrl)
+		err = browser.OpenReader(strings.NewReader(html))
+		if err != nil {
+			return err
+		}
 	} else {
 		err = browser.OpenURL(signinUrl)
 		if err != nil {
@@ -120,3 +128,16 @@ func getAWSSigninToken(accessKeyID string, secretAccessKey string, sessionToken 
 
 	return out.SigninToken, nil
 }
+
+const logoutHtmlTemplate = `
+	<body>
+		<script>
+			var iframe = document.createElement("iframe");
+			iframe.style = "visibility: hidden;";
+			iframe.src = "https://signin.aws.amazon.com/oauth?Action=logout";
+			iframe.onload = (event) => {
+				window.location = "%s";
+			};
+			document.body.appendChild(iframe);
+		</script>
+	</body>`


### PR DESCRIPTION
Adds a `--logout` flag to `kion console`. If `--logout` is specified, any current AWS console session is ended before the new console is opened, avoiding a "you must first log out" message.

To do this, we load the AWS logout page in an iframe (sending the needed cookies), then load the console. This is the same thing the Kion UI does.

Tested:
- `kion console --logout` with and without active sessions (macOS, Windows)