### PR TITLE
Improve login-related error messages

### DIFF
--- a/cmd/kion/config/config.go
+++ b/cmd/kion/config/config.go
@@ -61,9 +61,10 @@ const keyConfigFilename = "key.yml"
 type KeyConfig struct {
 	Key     string
 	Created time.Time
+	Expiry  time.Time
 }
 
-func LoadKeyConfig() (*KeyConfig, error) {
+func LoadKeyConfig(duration time.Duration) (*KeyConfig, error) {
 	dir, err := UserConfigDir()
 	if err != nil {
 		return nil, err
@@ -83,6 +84,13 @@ func LoadKeyConfig() (*KeyConfig, error) {
 	err = yaml.NewDecoder(f).Decode(&config)
 	if err != nil {
 		return nil, err
+	}
+
+	// Infer expiry for old config files. This can be removed once users have
+	// migrated to a version with KeyConfig.Expiry and the key config file has
+	// been updated, for example, by a rotation.
+	if config.Expiry.IsZero() {
+		config.Expiry = config.Created.Add(duration)
 	}
 
 	return &config, err

--- a/cmd/kion/config/config.go
+++ b/cmd/kion/config/config.go
@@ -61,10 +61,9 @@ const keyConfigFilename = "key.yml"
 type KeyConfig struct {
 	Key     string
 	Created time.Time
-	Expiry  time.Time
 }
 
-func LoadKeyConfig(duration time.Duration) (*KeyConfig, error) {
+func LoadKeyConfig() (*KeyConfig, error) {
 	dir, err := UserConfigDir()
 	if err != nil {
 		return nil, err
@@ -84,13 +83,6 @@ func LoadKeyConfig(duration time.Duration) (*KeyConfig, error) {
 	err = yaml.NewDecoder(f).Decode(&config)
 	if err != nil {
 		return nil, err
-	}
-
-	// Infer expiry for old config files. This can be removed once users have
-	// migrated to a version with KeyConfig.Expiry and the key config file has
-	// been updated, for example, by a rotation.
-	if config.Expiry.IsZero() {
-		config.Expiry = config.Created.Add(duration)
 	}
 
 	return &config, err

--- a/cmd/kion/key/key.go
+++ b/cmd/kion/key/key.go
@@ -112,7 +112,7 @@ func runRotate(cfg *config.Config, keyCfg *config.KeyConfig) error {
 		return err
 	}
 
-	// can't know exact expiry before calling, so pass zero Time
+	// can't know exact expiry before getting metadata, so pass zero Time meaning "no expiry"
 	kion = client.NewWithAppAPIKey(host, key.Key, time.Time{})
 	keyMetadata, err := kion.GetAppAPIKeyMetadata(key.ID)
 	if err != nil {

--- a/cmd/kion/key/key.go
+++ b/cmd/kion/key/key.go
@@ -62,10 +62,6 @@ func runCreate(cfg *config.Config, keyCfg *config.KeyConfig) error {
 	if err != nil {
 		return err
 	}
-	appAPIKeyDuration, err := cfg.DurationErr("app-api-key-duration")
-	if err != nil {
-		return err
-	}
 
 	password, err := keyring.Get(util.KeyringService(host, idms), username)
 	if errors.Is(err, keyring.ErrNotFound) {
@@ -97,7 +93,6 @@ func runCreate(cfg *config.Config, keyCfg *config.KeyConfig) error {
 
 	keyCfg.Key = key.Key
 	keyCfg.Created = keyMetadata.Created
-	keyCfg.Expiry = keyMetadata.Created.Add(appAPIKeyDuration)
 	return keyCfg.Save()
 }
 
@@ -111,7 +106,7 @@ func runRotate(cfg *config.Config, keyCfg *config.KeyConfig) error {
 		return err
 	}
 
-	kion := client.NewWithAppAPIKey(host, keyCfg.Key, keyCfg.Expiry)
+	kion := client.NewWithAppAPIKey(host, keyCfg.Key, keyCfg.Created.Add(appAPIKeyDuration))
 	key, err := kion.RotateAppAPIKey(keyCfg.Key)
 	if err != nil {
 		return err
@@ -126,6 +121,5 @@ func runRotate(cfg *config.Config, keyCfg *config.KeyConfig) error {
 
 	keyCfg.Key = key.Key
 	keyCfg.Created = keyMetadata.Created
-	keyCfg.Expiry = keyMetadata.Created.Add(appAPIKeyDuration)
 	return keyCfg.Save()
 }

--- a/cmd/kion/kion.go
+++ b/cmd/kion/kion.go
@@ -22,6 +22,7 @@ import (
 	"github.com/knadh/koanf/providers/posflag"
 	"github.com/knadh/koanf/v2"
 	"github.com/spf13/cobra"
+	"github.com/zalando/go-keyring"
 )
 
 func main() {
@@ -82,7 +83,9 @@ func main() {
 	if err != nil {
 		program := os.Args[0]
 		var message string
-		if errors.Is(err, client.ErrAppAPIKeyExpired) {
+		if errors.Is(err, keyring.ErrNotFound) {
+			message = fmt.Sprintf("no credentials; run \"%s login\" to store user credentials in the system keyring or \"%s key create\" to create an app API key", program, program)
+		} else if errors.Is(err, client.ErrAppAPIKeyExpired) {
 			message = fmt.Sprintf("app API key expired; run \"%s key create --force\"", program)
 		} else {
 			message = err.Error()

--- a/cmd/kion/kion.go
+++ b/cmd/kion/kion.go
@@ -85,6 +85,8 @@ func main() {
 		var message string
 		if errors.Is(err, keyring.ErrNotFound) {
 			message = fmt.Sprintf("no credentials; run \"%s login\" to store user credentials in the system keyring or \"%s key create\" to create an app API key", program, program)
+		} else if errors.Is(err, client.ErrInvalidCredentials) {
+			message = fmt.Sprintf("login failed; run \"%s login\" to update credentials", program)
 		} else if errors.Is(err, client.ErrAppAPIKeyExpired) {
 			message = fmt.Sprintf("app API key expired; run \"%s key create --force\"", program)
 		} else {

--- a/cmd/kion/kion.go
+++ b/cmd/kion/kion.go
@@ -61,11 +61,7 @@ func main() {
 
 	cfg := &config.Config{Koanf: k}
 
-	// LoadKeyConfig needs the duration to infer the expiry for old config
-	// files. This can be removed once users have migrated to the new version.
-	// If it's removed before everyone migrates, the only issue would be that
-	// we'd report "expired" when keys are invalid for any reason.
-	keyCfg, err := config.LoadKeyConfig(cfg.Duration("app-api-key-duration"))
+	keyCfg, err := config.LoadKeyConfig()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/kion/util/util.go
+++ b/cmd/kion/util/util.go
@@ -34,7 +34,7 @@ func NewClient(cfg *config.Config, keyCfg *config.KeyConfig) (*client.Client, er
 					return nil, err
 				}
 
-				// can't know exact expiry before calling, so pass zero Time
+				// can't know exact expiry before getting metadata, so pass zero Time meaning "no expiry"
 				kion = client.NewWithAppAPIKey(host, key.Key, time.Time{})
 				keyMetadata, err := kion.GetAppAPIKeyMetadata(key.ID)
 				if err != nil {

--- a/cmd/kion/util/util.go
+++ b/cmd/kion/util/util.go
@@ -61,7 +61,6 @@ func NewClient(cfg *config.Config, keyCfg *config.KeyConfig) (*client.Client, er
 		return nil, err
 	}
 
-	// TODO: better error if no creds
 	password, err := keyring.Get(KeyringService(host, idms), username)
 	if err != nil {
 		return nil, err

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -49,7 +49,7 @@ type accessToken struct {
 }
 
 func (t *accessToken) IsExpired() bool {
-	return time.Now().After(t.Expiry)
+	return !t.Expiry.IsZero() && time.Now().After(t.Expiry)
 }
 
 func NewWithAppAPIKey(host string, key string, expiry time.Time) *Client {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -12,12 +12,13 @@ import (
 	"github.com/relvacode/iso8601"
 )
 
+var ErrAppAPIKeyExpired = errors.New("kion: app API key expired")
 var ErrInvalidCredentials = errors.New("kion: invalid credentials")
 var ErrUnauthorized = errors.New("kion: unauthorized")
 
 type Client struct {
 	Host        string
-	accessToken string
+	accessToken *accessToken
 }
 
 type AppAPIKey struct {
@@ -41,10 +42,24 @@ type TemporaryCredentials struct {
 	SessionToken    string `json:"session_token"`
 }
 
-func NewWithAppAPIKey(host string, key string) *Client {
+type accessToken struct {
+	Token       string
+	Expiry      time.Time
+	IsAppAPIKey bool
+}
+
+func (t *accessToken) IsExpired() bool {
+	return time.Now().After(t.Expiry)
+}
+
+func NewWithAppAPIKey(host string, key string, expiry time.Time) *Client {
 	return &Client{
-		Host:        host,
-		accessToken: key,
+		Host: host,
+		accessToken: &accessToken{
+			Token:       key,
+			Expiry:      expiry,
+			IsAppAPIKey: true,
+		},
 	}
 }
 
@@ -61,14 +76,18 @@ func Login(host string, idms int, username string, password string) (*Client, er
 		}
 	}{}
 
-	err := do(http.MethodPost, host, "", "v3/token", req, &resp)
+	err := do(http.MethodPost, host, nil, "v3/token", req, &resp)
 	if err != nil {
 		return nil, err
 	}
 
 	client := Client{
-		Host:        host,
-		accessToken: resp.Access.Token,
+		Host: host,
+		accessToken: &accessToken{
+			Token:       resp.Access.Token,
+			Expiry:      time.Time{},
+			IsAppAPIKey: false,
+		},
 	}
 	return &client, nil
 }
@@ -76,7 +95,7 @@ func Login(host string, idms int, username string, password string) (*Client, er
 func GetIDMSs(host string) ([]IDMS, error) {
 	resp := []IDMS{}
 
-	err := do(http.MethodGet, host, "", "v2/idms", nil, &resp)
+	err := do(http.MethodGet, host, nil, "v2/idms", nil, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +197,11 @@ func (c *Client) do(method string, path string, data interface{}, out interface{
 	return do(method, c.Host, c.accessToken, path, data, out)
 }
 
-func do(method string, host string, accessToken string, path string, data interface{}, out interface{}) error {
+func do(method string, host string, accessToken *accessToken, path string, data interface{}, out interface{}) error {
+	if accessToken != nil && accessToken.IsAppAPIKey && accessToken.IsExpired() {
+		return ErrAppAPIKeyExpired
+	}
+
 	u := url.URL{
 		Scheme: "https",
 		Host:   host,
@@ -198,8 +221,8 @@ func do(method string, host string, accessToken string, path string, data interf
 	if err != nil {
 		return err
 	}
-	if accessToken != "" {
-		req.Header.Add("Authorization", "Bearer "+accessToken)
+	if accessToken != nil {
+		req.Header.Add("Authorization", "Bearer "+accessToken.Token)
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -52,6 +52,9 @@ func (t *accessToken) IsExpired() bool {
 	return !t.Expiry.IsZero() && time.Now().After(t.Expiry)
 }
 
+// NewWithAppAPIKey creates a Client that authenticates with an App API Key.
+// expiry allows the Client to generate an error if it is used after the key has
+// expired. A zero expiry (time.Time{}) means the key doesn't expire.
 func NewWithAppAPIKey(host string, key string, expiry time.Time) *Client {
 	return &Client{
 		Host: host,


### PR DESCRIPTION
## PR Description
Improves error messages when there are no credentials, bad credentials, or expired App API Key. This PR is probably easiest to review commit by commit.

To make sure we always detect expired keys, the check is done in `client.Client`. This means that users of `Client` must now provide the expiry when they create a `Client` with a key. To avoid computing the expiry everywhere `Client` is used, this PR adds the value to `key.yml`. This also prevents the expiry of existing keys from changing if the `api-api-key-duration` setting is changed.

(It's surprising that Kion doesn't return the expiry of App API Keys, only the creation date. I might request this feature.)

Tested:
- Ran program with the three conditions, verified output, ran suggested commands

## PR Checklist
* [x] **New automated tests have been written to the extent possible.**
* [x] **The code has been checked for structural/syntactic validity.**
	- AMI/application: a build was performed
	- terraform changes: "terraform plan" checked on every affected environment
* [x] **(If applicable) the code has been manually tested on our infrastructure.**
	- AMI/application: deployed an a test or dev environment
	- terraform changes: applied to test or dev environment
	- script: run against test or dev environment
* [x] **Likely failure points and new functionality have been identified and tested manually.**
	Examples:
	- Application manually run in a way that triggers any new branches
	- AMI logged into and changes verified from login shell
* [x] **Pull request description includes a description of all the manual steps performed to accomplish the above.**

To provide feedback on this template, visit https://docs.google.com/document/d/1YfTv7Amyop5G_8w1c2GJ_Mu-70L0KkZHhm9f9umDi3U/edit
