### PR TITLE
Add access subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,26 @@ To remove credentials from the system keychain:
 $ kion logout
 ```
 
+## Printing Access Info
+
+The `access` subcommand prints the current user's Cloud Access Roles and associated accounts. Each line contains a Cloud Access Role, account ID, and account name:
+
+```
+$ kion access
+role1	123412341234	account1
+role1	234123412341	account2
+role2	123412341234	account1
+role2	234123412341	account2
+```
+
+The list can be filtered with the `--cloud-access-role` (`-r`), `--account-id`, and `--account` flags:
+
+```
+$ kion access --cloud-access-role role1
+role1	123412341234	account1
+role1	234123412341	account2
+```
+
 ## Scenario: Terraform
 
 Combining the features above, you can configure Terraform to fetch credentials from Kion transparently.

--- a/cmd/kion/access/access.go
+++ b/cmd/kion/access/access.go
@@ -1,0 +1,58 @@
+package access
+
+import (
+	"fmt"
+
+	"github.com/corbaltcode/kion/cmd/kion/config"
+	"github.com/corbaltcode/kion/cmd/kion/util"
+	"github.com/spf13/cobra"
+)
+
+func New(cfg *config.Config, keyCfg *config.KeyConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "access",
+		Short: "Prints roles and associated accounts",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cfg, keyCfg)
+		},
+	}
+
+	cmd.Flags().StringP("account", "", "", "filter by account name")
+	cmd.Flags().StringP("account-id", "", "", "filter by account ID")
+	cmd.Flags().StringP("cloud-access-role", "r", "", "filter by cloud access role")
+
+	return cmd
+}
+
+func run(cfg *config.Config, keyCfg *config.KeyConfig) error {
+	account := cfg.String("account")
+	accountID := cfg.String("account-id")
+	role := cfg.String("cloud-access-role")
+
+	kion, err := util.NewClient(cfg, keyCfg)
+	if err != nil {
+		return err
+	}
+
+	acars, err := kion.GetAccountCloudAccessRoles()
+	if err != nil {
+		return err
+	}
+
+	for _, acar := range acars {
+		if account != "" && account != acar.AccountName {
+			continue
+		}
+		if accountID != "" && accountID != acar.AccountID {
+			continue
+		}
+		if role != "" && role != acar.CloudAccessRole {
+			continue
+		}
+
+		fmt.Printf("%v\t%v\t%v\n", acar.CloudAccessRole, acar.AccountID, acar.AccountName)
+	}
+
+	return nil
+}

--- a/cmd/kion/kion.go
+++ b/cmd/kion/kion.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/corbaltcode/kion/cmd/kion/access"
 	"github.com/corbaltcode/kion/cmd/kion/config"
 	"github.com/corbaltcode/kion/cmd/kion/console"
 	"github.com/corbaltcode/kion/cmd/kion/credentialprocess"
@@ -67,6 +68,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	rootCmd.AddCommand(access.New(cfg, keyCfg))
 	rootCmd.AddCommand(credentialprocess.New(cfg, keyCfg))
 	rootCmd.AddCommand(credentials.New(cfg, keyCfg))
 	rootCmd.AddCommand(console.New(cfg, keyCfg))

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -21,6 +21,12 @@ type Client struct {
 	accessToken *accessToken
 }
 
+type AccountCloudAccessRole struct {
+	AccountID       string `json:"account_number"`
+	AccountName     string `json:"account_name"`
+	CloudAccessRole string `json:"name"`
+}
+
 type AppAPIKey struct {
 	ID  int
 	Key string
@@ -154,6 +160,18 @@ func (c *Client) GetAppAPIKeyMetadata(id int) (*AppAPIKeyMetadata, error) {
 		ID:      resp.ID,
 		Created: created,
 	}, nil
+}
+
+func (c *Client) GetAccountCloudAccessRoles() ([]AccountCloudAccessRole, error) {
+	resp := []AccountCloudAccessRole{}
+
+	// this method returns a join of cloud access role and account
+	err := c.do(http.MethodGet, "v3/me/cloud-access-role", nil, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
 func (c *Client) GetTemporaryCredentialsByIAMRole(accountID string, iamRole string) (*TemporaryCredentials, error) {


### PR DESCRIPTION
Adds a subcommand for printing Cloud Access Roles and associated accounts.

Tested:
- `kion access`
- `kion access --account <account>`
- Other ad hoc testing