### PR TITLE
Add GovCloud Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Run `kion setup` to set up kion interactively. This subcommand asks for your Kio
 app-api-key-duration: 168h0m0s
 host: kion.example.com
 idms: 1
-region: us-east-1
 rotate-app-api-keys: true
 session-duration: 1h0m0s
 username: alice

--- a/cmd/kion/console/console.go
+++ b/cmd/kion/console/console.go
@@ -67,7 +67,7 @@ func run(cfg *config.Config, keyCfg *config.KeyConfig) error {
 	case client.AccountTypeGovCloud:
 		awsDomain = "amazonaws-us-gov.com"
 	default:
-		panic(fmt.Sprintf("unexpected account type: %d", accountInfo.Type))
+		return errors.New(fmt.Sprintf("unexpected account type: %d", accountInfo.Type))
 	}
 
 	creds, err := kion.GetTemporaryCredentialsByCloudAccessRole(accountID, cloudAccessRole)

--- a/cmd/kion/console/console.go
+++ b/cmd/kion/console/console.go
@@ -29,7 +29,6 @@ func New(cfg *config.Config, keyCfg *config.KeyConfig) *cobra.Command {
 	cmd.Flags().StringP("cloud-access-role", "", "", "cloud access role")
 	cmd.Flags().BoolP("print", "p", false, "print URL instead of opening a browser")
 	cmd.Flags().BoolP("logout", "", false, "log out of existing AWS console session")
-	cmd.Flags().StringP("region", "", "", "AWS region")
 	cmd.Flags().StringP("session-duration", "", "1h", "duration of temporary credentials")
 
 	return cmd
@@ -46,10 +45,6 @@ func run(cfg *config.Config, keyCfg *config.KeyConfig) error {
 		return err
 	}
 	host, err := cfg.StringErr("host")
-	if err != nil {
-		return err
-	}
-	region, err := cfg.StringErr("region")
 	if err != nil {
 		return err
 	}
@@ -71,7 +66,7 @@ func run(cfg *config.Config, keyCfg *config.KeyConfig) error {
 	v := url.Values{}
 	v.Add("Action", "login")
 	v.Add("Issuer", fmt.Sprintf("https://%s/login", host))
-	v.Add("Destination", fmt.Sprintf("https://%s.console.aws.amazon.com", region))
+	v.Add("Destination", "https://console.aws.amazon.com")
 	v.Add("SigninToken", signinToken)
 	signinUrl := "https://signin.aws.amazon.com/federation?" + v.Encode()
 

--- a/cmd/kion/console/console.go
+++ b/cmd/kion/console/console.go
@@ -108,7 +108,7 @@ func run(cfg *config.Config, keyCfg *config.KeyConfig) error {
 
 	return nil
 }
-func getAWSSigninToken(awsEndpoint string, accessKeyID string, secretAccessKey string, sessionToken string) (string, error) {
+func getAWSSigninToken(awsDomain string, accessKeyID string, secretAccessKey string, sessionToken string) (string, error) {
 	session := map[string]string{
 		"sessionId":    accessKeyID,
 		"sessionKey":   secretAccessKey,
@@ -122,7 +122,7 @@ func getAWSSigninToken(awsEndpoint string, accessKeyID string, secretAccessKey s
 	v := url.Values{}
 	v.Add("Action", "getSigninToken")
 	v.Add("Session", string(sessionJSON))
-	url := fmt.Sprintf("https://signin.%s/federation?", awsEndpoint) + v.Encode()
+	url := fmt.Sprintf("https://signin.%s/federation?", awsDomain) + v.Encode()
 
 	resp, err := http.DefaultClient.Get(url)
 	if err != nil {

--- a/cmd/kion/setup/setup.go
+++ b/cmd/kion/setup/setup.go
@@ -184,21 +184,10 @@ func run() error {
 		return err
 	}
 
-	var region string
-	err = survey.AskOne(
-		&survey.Input{Message: "Default region:", Default: "us-east-1"},
-		&region,
-		survey.WithValidator(survey.Required),
-	)
-	if err != nil {
-		return err
-	}
-
 	settings := map[string]interface{}{
 		"app-api-key-duration": appAPIKeyDuration,
 		"host":                 host,
 		"idms":                 idms.ID,
-		"region":               region,
 		"rotate-app-api-keys":  rotateAppAPIKeys,
 		"session-duration":     sessionDuration,
 		"username":             username,

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -48,13 +48,18 @@ type TemporaryCredentials struct {
 	SessionToken    string `json:"session_token"`
 }
 
-type AccountDetails struct {
-	AccountName   string `json:"account_name"`
-	AccountNumber string `json:"account_number"`
-	AccountTypeID int64  `json:"account_type_id"`
-	CreatedAt     string `json:"created_at"`
-	DeletedAt     string `json:"deleted_at"`
-	ID            int64  `json:"id"`
+type AccountType int
+
+const (
+	AccountTypeUnknown    AccountType = 0
+	AccountTypeCommercial AccountType = 1
+	AccountTypeGovCloud   AccountType = 2
+)
+
+type Account struct {
+	Name string      `json:"account_name"`
+	ID   string      `json:"account_number"`
+	Type AccountType `json:"account_type_id"`
 }
 
 type accessToken struct {
@@ -213,8 +218,8 @@ func (c *Client) GetTemporaryCredentialsByCloudAccessRole(accountID string, clou
 	return &resp, nil
 }
 
-func (c *Client) GetAccountByID(accountID string) (*AccountDetails, error) {
-	resp := AccountDetails{}
+func (c *Client) GetAccountByID(accountID string) (*Account, error) {
+	resp := Account{}
 
 	err := c.do(http.MethodGet, fmt.Sprintf("v3/account/by-account-number/%s", accountID), nil, &resp)
 	if err != nil {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -48,6 +48,15 @@ type TemporaryCredentials struct {
 	SessionToken    string `json:"session_token"`
 }
 
+type AccountDetails struct {
+	AccountName   string `json:"account_name"`
+	AccountNumber string `json:"account_number"`
+	AccountTypeID int64  `json:"account_type_id"`
+	CreatedAt     string `json:"created_at"`
+	DeletedAt     string `json:"deleted_at"`
+	ID            int64  `json:"id"`
+}
+
 type accessToken struct {
 	Token       string
 	Expiry      time.Time
@@ -197,6 +206,17 @@ func (c *Client) GetTemporaryCredentialsByCloudAccessRole(accountID string, clou
 	resp := TemporaryCredentials{}
 
 	err := c.do(http.MethodPost, "v3/temporary-credentials/cloud-access-role", req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (c *Client) GetAccountByID(accountID string) (*AccountDetails, error) {
+	resp := AccountDetails{}
+
+	err := c.do(http.MethodGet, fmt.Sprintf("v3/account/by-account-number/%s", accountID), nil, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -51,7 +51,6 @@ type TemporaryCredentials struct {
 type AccountType int
 
 const (
-	AccountTypeUnknown    AccountType = 0
 	AccountTypeCommercial AccountType = 1
 	AccountTypeGovCloud   AccountType = 2
 )


### PR DESCRIPTION
## PR Description

Adds GovCloud support for building the AWS signin url when using the `kion console` command.

- adds an additional API call to CloudTamer to retrieve the account information to determine account type
- this change has been tested against Commercial and GovCloud accounts using `kion console`

## PR Checklist
* [ ] **New automated tests have been written to the extent possible.**
* [x] **The code has been checked for structural/syntactic validity.**
	- AMI/application: a build was performed
	- terraform changes: "terraform plan" checked on every affected environment
* [ ] **(If applicable) the code has been manually tested on our infrastructure.**
	- AMI/application: deployed an a test or dev environment
	- terraform changes: applied to test or dev environment
	- script: run against test or dev environment
* [x] **Likely failure points and new functionality have been identified and tested manually.**
	Examples:
	- Application manually run in a way that triggers any new branches
	- AMI logged into and changes verified from login shell
* [x] **Pull request description includes a description of all the manual steps performed to accomplish the above.**

To provide feedback on this template, visit https://docs.google.com/document/d/1YfTv7Amyop5G_8w1c2GJ_Mu-70L0KkZHhm9f9umDi3U/edit
